### PR TITLE
Added watchdog alerts first

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -291,14 +291,14 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, consoleUrl strin
 	routes := []*alertmanager.Route{}
 	receivers := []*alertmanager.Receiver{}
 
-	if pagerdutyRoutingKey != "" {
-		routes = append(routes, createPagerdutyRoute())
-		receivers = append(receivers, createPagerdutyReceivers(pagerdutyRoutingKey, consoleUrl, clusterID)...)
-	}
-
 	if watchdogURL != "" {
 		routes = append(routes, createWatchdogRoute())
 		receivers = append(receivers, createWatchdogReceivers(watchdogURL)...)
+	}
+
+	if pagerdutyRoutingKey != "" {
+		routes = append(routes, createPagerdutyRoute())
+		receivers = append(receivers, createPagerdutyReceivers(pagerdutyRoutingKey, consoleUrl, clusterID)...)
 	}
 
 	// always have the "null" receiver

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -445,10 +445,10 @@ func Test_createAlertManagerConfig_WithKey_WithURL(t *testing.T) {
 
 	verifyNullReceiver(t, config.Receivers)
 
-	verifyPagerdutyRoute(t, config.Route.Routes[0])
+	verifyPagerdutyRoute(t, config.Route.Routes[1])
 	verifyPagerdutyReceivers(t, pdKey, config.Receivers)
 
-	verifyWatchdogRoute(t, config.Route.Routes[1])
+	verifyWatchdogRoute(t, config.Route.Routes[0])
 	verifyWatchdogReceiver(t, wdURL, config.Receivers)
 
 	verifyInhibitRules(t, config.InhibitRules)


### PR DESCRIPTION
A namespace was added to the watch dog alert that is matching rules prior to the watchdog rule on the config. I changed the order in which the config is made so that watchdog is matched first.

https://bugzilla.redhat.com/show_bug.cgi?id=2003181

Fixed Upstream via this: https://github.com/openshift/configure-alertmanager-operator/pull/187
